### PR TITLE
Update for Express 4.0

### DIFF
--- a/app.js
+++ b/app.js
@@ -7,17 +7,21 @@ server = require('http').createServer(app),
 routes = require('./routes'),
 api = require('./routes/api');
 
-app.configure(function() {
-  app.locals.pretty = true;
-  app.use(express.bodyParser());
-  app.use(express.methodOverride());
-  app.use(express.static(__dirname + '/public'));
-  app.use('/components', express.static(__dirname + '/components'));
-  app.use('/js', express.static(__dirname + '/js'));
-  app.use(app.router);
-  app.engine('html', require('ejs').renderFile);
-});
-server.listen(3000, "192.168.56.102",  function(){
+// Express middlware
+var bodyParser = require('body-parser');
+var methodOverride = require('method-override');
+
+// Express configuration
+app.locals.pretty = true;
+app.use(bodyParser());
+app.use(methodOverride());
+app.use(express.static(__dirname + '/public'));
+app.use('/components', express.static(__dirname + '/components'));
+app.use('/js', express.static(__dirname + '/js'));
+// app.use(app.router);
+app.engine('html', require('ejs').renderFile);
+
+server.listen(3000, "localhost",  function(){
   console.log("Express server up and running.");
 });
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "twit": "latest",
     "express": "latest",
     "nodemon": "latest",
-    "ejs": "latest"
+    "ejs": "latest",
+    "body-parser": "latest",
+    "method-override": "latest"
   },
   "scripts": {
     "start": "NODE_PATH=./app/controllers NODE_ENV=development ./node_modules/.bin/nodemon app.js"


### PR DESCRIPTION
Follow-up to the issue raised regarding compatibility with Express v4.0:

app.config was removed from app.js, and some dependencies that are no longer bundled with Express have been added to package.json. app.routes was also removed.

Tested locally and appears to work ok with latest Express version (4.12 at the time of writing).

Suggest also altering dependency refs to specific versions instead of 'latest'
